### PR TITLE
fix: lang pt-BR, favicon, validação de senha (8 chars)

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,10 +1,10 @@
 <!doctype html>
-<html lang="en">
+<html lang="pt-BR">
   <head>
     <meta charset="UTF-8" />
-    <link rel="icon" type="image/svg+xml" href="/vite.svg" />
+    <link rel="icon" type="image/png" href="/wallet.png" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>controle-de-gastos</title>
+    <title>Controle de Gastos</title>
   </head>
   <body>
     <div id="root"></div>

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -11,7 +11,7 @@ import PageTransition from '@/components/PageTransition';
 
 const loginSchema = z.object({
   email: z.string().email('E-mail inválido'),
-  password: z.string().min(6, 'A senha deve ter pelo menos 6 caracteres'),
+  password: z.string().min(8, 'A senha deve ter pelo menos 8 caracteres'),
 });
 
 type LoginForm = z.infer<typeof loginSchema>;


### PR DESCRIPTION
## �� Correções de UI

- `index.html`: `lang="pt-BR"` (era `en`)
- `index.html`: favicon trocado de `/vite.svg` para `/wallet.png`
- `index.html`: título capitalizado para `Controle de Gastos`
- `Login.tsx`: validação de senha atualizada para mínimo de 8 caracteres (alinhado com as regras do Supabase Auth)