### PR TITLE
feat: keep Supabase alive via GitHub Actions cron (#39)

### DIFF
--- a/.github/workflows/keep-supabase-alive.yml
+++ b/.github/workflows/keep-supabase-alive.yml
@@ -1,0 +1,17 @@
+name: Keep Supabase Alive
+
+on:
+  schedule:
+    - cron: '0 12 */3 * *' # a cada 3 dias ao meio-dia UTC
+  workflow_dispatch: # permite rodar manualmente pela UI do GitHub
+
+jobs:
+  ping:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Ping Supabase REST API
+        run: |
+          curl -X GET "https://opxmevzhrjuqjslhbsov.supabase.co/rest/v1/" \
+            -H "apikey: ${{ secrets.SUPABASE_ANON_KEY }}" \
+            --fail --silent --show-error
+          echo "✅ Supabase pinged successfully"


### PR DESCRIPTION
## 📌 Issue #39 — Keep Supabase Alive

Implementa a Opção B: cron job via GitHub Actions.

### O que faz
- Executa um `curl` no endpoint REST do Supabase **a cada 3 dias**
- Evita que o projeto seja pausado por inatividade no free tier
- Também pode ser rodado **manualmente** pela aba Actions (`workflow_dispatch`)

### Configuração
- Secret `SUPABASE_ANON_KEY` adicionado ao repositório