### PR TITLE
db: add recurrence columns and frequency enum to schema

### DIFF
--- a/server/database/schema.sql
+++ b/server/database/schema.sql
@@ -1,5 +1,5 @@
--- Criação do Enum para Tipos de Transações (Entrada/Saída)
 CREATE TYPE transaction_type AS ENUM ('income', 'expense');
+CREATE TYPE recurrence_frequency AS ENUM ('weekly', 'monthly', 'yearly');
 
 -- Tabela de Categorias
 CREATE TABLE categories (
@@ -20,6 +20,9 @@ CREATE TABLE transactions (
   date DATE NOT NULL,
   category_id UUID REFERENCES categories(id) ON DELETE SET NULL,
   user_id UUID NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  is_recurrent BOOLEAN DEFAULT false,
+  frequency recurrence_frequency,
+  parent_id UUID REFERENCES transactions(id) ON DELETE CASCADE,
   created_at TIMESTAMP WITH TIME ZONE DEFAULT TIMEZONE('utc'::text, NOW()) NOT NULL
 );
 


### PR DESCRIPTION
This pull request introduces support for recurring transactions in the database schema. The main changes add new fields to the `transactions` table and define a new enum type to represent recurrence frequency.

**Recurring transactions support:**

* Added a new enum type `recurrence_frequency` with values `'weekly'`, `'monthly'`, and `'yearly'` to represent the frequency of recurring transactions.
* Updated the `transactions` table to include:
  * `is_recurrent` boolean field to indicate if a transaction is recurring (default: false),
  * `frequency` field of type `recurrence_frequency` to specify how often the transaction recurs,
  * `parent_id` field referencing another transaction, allowing grouping of recurring transaction instances.