### PR TITLE
feat(db): add user automation trigger and default categories function

### DIFF
--- a/server/database/schema.sql
+++ b/server/database/schema.sql
@@ -101,3 +101,47 @@ WITH CHECK (auth.uid() = id);
 
 -- Trigger para criar perfil automaticamente no SignUp (Opcional, mas recomendado)
 -- Vamos deixar manual por enquanto via frontend para simplificar a lógica inicial.
+-- Migration: Automação de Novo Usuário (Perfis e Categorias)
+-- Issue: #02
+
+-- 1. Função para lidar com o novo usuário
+CREATE OR REPLACE FUNCTION public.handle_new_user()
+RETURNS trigger AS $$
+BEGIN
+  -- Inserir Perfil automático
+  INSERT INTO public.profiles (id, full_name, avatar_url)
+  VALUES (
+    new.id, 
+    new.raw_user_meta_data->>'full_name', 
+    new.raw_user_meta_data->>'avatar_url'
+  );
+
+  -- Inserir Categorias Padrão automáticas
+  INSERT INTO public.categories (name, icon, color, user_id)
+  VALUES
+    ('Salário', 'banknote', '#10B981', new.id),
+    ('Investimentos', 'trending-up', '#059669', new.id),
+    ('Moradia', 'home', '#3B82F6', new.id),
+    ('Conta de Luz', 'zap', '#F59E0B', new.id),
+    ('Conta de Água', 'droplets', '#06B6D4', new.id),
+    ('Internet', 'wifi', '#6366F1', new.id),
+    ('Supermercado', 'shopping-cart', '#8B5CF6', new.id),
+    ('Alimentação', 'utensils', '#EF4444', new.id),
+    ('Transporte', 'car', '#6B7280', new.id),
+    ('Lazer', 'clapperboard', '#F472B6', new.id),
+    ('Saúde', 'heart', '#10B981', new.id),
+    ('Educação', 'graduation-cap', '#4F46E5', new.id),
+    ('Assinaturas', 'tv', '#EC4899', new.id),
+    ('Vestuário', 'shirt', '#D946EF', new.id);
+
+  RETURN new;
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER;
+
+-- 2. Trigger para disparar após a criação do usuário no Auth
+DROP TRIGGER IF EXISTS on_auth_user_created ON auth.users;
+CREATE TRIGGER on_auth_user_created
+  AFTER INSERT ON auth.users
+  FOR EACH ROW EXECUTE FUNCTION public.handle_new_user();
+
+COMMENT ON FUNCTION public.handle_new_user() IS 'Cria perfil e categorias padrão automaticamente para novos usuários do Auth';

--- a/supabase/migrations/20260420_user_automation.sql
+++ b/supabase/migrations/20260420_user_automation.sql
@@ -1,0 +1,44 @@
+-- Migration: Automação de Novo Usuário (Perfis e Categorias)
+-- Issue: #02
+
+-- 1. Função para lidar com o novo usuário
+CREATE OR REPLACE FUNCTION public.handle_new_user()
+RETURNS trigger AS $$
+BEGIN
+  -- Inserir Perfil automático
+  INSERT INTO public.profiles (id, full_name, avatar_url)
+  VALUES (
+    new.id, 
+    new.raw_user_meta_data->>'full_name', 
+    new.raw_user_meta_data->>'avatar_url'
+  );
+
+  -- Inserir Categorias Padrão automáticas
+  INSERT INTO public.categories (name, icon, color, user_id)
+  VALUES
+    ('Salário', 'banknote', '#10B981', new.id),
+    ('Investimentos', 'trending-up', '#059669', new.id),
+    ('Moradia', 'home', '#3B82F6', new.id),
+    ('Conta de Luz', 'zap', '#F59E0B', new.id),
+    ('Conta de Água', 'droplets', '#06B6D4', new.id),
+    ('Internet', 'wifi', '#6366F1', new.id),
+    ('Supermercado', 'shopping-cart', '#8B5CF6', new.id),
+    ('Alimentação', 'utensils', '#EF4444', new.id),
+    ('Transporte', 'car', '#6B7280', new.id),
+    ('Lazer', 'clapperboard', '#F472B6', new.id),
+    ('Saúde', 'heart', '#10B981', new.id),
+    ('Educação', 'graduation-cap', '#4F46E5', new.id),
+    ('Assinaturas', 'tv', '#EC4899', new.id),
+    ('Vestuário', 'shirt', '#D946EF', new.id);
+
+  RETURN new;
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER;
+
+-- 2. Trigger para disparar após a criação do usuário no Auth
+DROP TRIGGER IF EXISTS on_auth_user_created ON auth.users;
+CREATE TRIGGER on_auth_user_created
+  AFTER INSERT ON auth.users
+  FOR EACH ROW EXECUTE FUNCTION public.handle_new_user();
+
+COMMENT ON FUNCTION public.handle_new_user() IS 'Cria perfil e categorias padrão automaticamente para novos usuários do Auth';


### PR DESCRIPTION
This pull request introduces automation for onboarding new users by creating their profile and a set of default categories as soon as they register. The logic is implemented via a new database function and trigger, ensuring that every new user in the authentication system receives a profile and pre-configured categories without manual intervention.

**User onboarding automation:**

* Added the `public.handle_new_user()` function to automatically create a new entry in the `profiles` table and insert a set of default categories into the `categories` table whenever a new user is created in `auth.users`. [[1]](diffhunk://#diff-d138c5e87131385e1bfb51599be534e2bca7f856f85b5bfa9990d029e8c43eb6R104-R147) [[2]](diffhunk://#diff-f13bb4659362e456d4f7beee63904f8c7816eafd84e066c528e8f8a77e283177R1-R44)
* Created a trigger `on_auth_user_created` on the `auth.users` table to execute the `handle_new_user()` function after each new user insertion, ensuring the automation runs seamlessly on user signup. [[1]](diffhunk://#diff-d138c5e87131385e1bfb51599be534e2bca7f856f85b5bfa9990d029e8c43eb6R104-R147) [[2]](diffhunk://#diff-f13bb4659362e456d4f7beee63904f8c7816eafd84e066c528e8f8a77e283177R1-R44)
* Added a comment to document the purpose of the `handle_new_user()` function for future maintainers. [[1]](diffhunk://#diff-d138c5e87131385e1bfb51599be534e2bca7f856f85b5bfa9990d029e8c43eb6R104-R147) [[2]](diffhunk://#diff-f13bb4659362e456d4f7beee63904f8c7816eafd84e066c528e8f8a77e283177R1-R44)