### PR TITLE
feat: implement recurring transactions logic using RPC

### DIFF
--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, waitFor } from '@testing-library/react';
+import { render, waitFor } from '@testing-library/react';
 import { describe, it, expect, vi } from 'vitest';
 import { MemoryRouter } from 'react-router-dom';
 

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -1,4 +1,4 @@
-import { render } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
 import { describe, it, expect, vi } from 'vitest';
 import { MemoryRouter } from 'react-router-dom';
 
@@ -39,7 +39,7 @@ Object.defineProperty(window, 'matchMedia', {
 });
 
 describe('App', () => {
-  it('renders without crashing (Smoke Test)', () => {
+  it('renders without crashing (Smoke Test)', async () => {
     // Renders the app inside a MemoryRouter for AuthRoutes and AppRoutes to work
     render(
       <MemoryRouter>
@@ -48,6 +48,12 @@ describe('App', () => {
         </AuthProvider>
       </MemoryRouter>,
     );
+
+    // Wait for initial loading to finish to avoid "act" warnings from async state updates
+    await waitFor(() => {
+      // The spinner is rendered in RouteGuards while isLoading is true
+      expect(document.querySelector('.animate-spin')).not.toBeInTheDocument();
+    });
 
     // In our unlogged main structure, <App> will take us to either Login or Loading Splash routes
     // Only check if the main elements of div or root existed without crashing.

--- a/src/components/TransactionForm.test.tsx
+++ b/src/components/TransactionForm.test.tsx
@@ -16,6 +16,7 @@ const mockQuery = {
 vi.mock('@/services/supabase', () => ({
   supabase: {
     from: vi.fn(() => mockQuery),
+    rpc: vi.fn().mockResolvedValue({ data: null, error: null }),
     auth: { getUser: vi.fn().mockResolvedValue({ data: { user: { id: 'u-123' } }, error: null }) },
   },
 }));
@@ -129,16 +130,15 @@ describe('TransactionForm', () => {
     fireEvent.click(screen.getByText('Salvar Transação'));
 
     await waitFor(() => {
-      expect(supabase.from).toHaveBeenCalledWith('transactions');
-      expect(mockQuery.insert).toHaveBeenCalledWith([
-        expect.objectContaining({
-          description: 'Compra Recorrente',
-          amount: 150,
-          is_recurrent: true,
-          frequency: 'monthly',
-          installments: 10,
-        }),
-      ]);
+      expect(supabase.rpc).toHaveBeenCalledWith('handle_recurring_transactions', {
+        p_description: 'Compra Recorrente',
+        p_amount: 150,
+        p_date: expect.any(String),
+        p_type: 'expense',
+        p_category_id: null,
+        p_frequency: 'monthly',
+        p_installments: 10,
+      });
     });
   });
 

--- a/src/components/TransactionForm.tsx
+++ b/src/components/TransactionForm.tsx
@@ -139,11 +139,23 @@ export default function TransactionForm({
         if (!user) throw new Error('Usuário não autenticado');
         const finalPayload = { ...payload, user_id: user.id };
 
-        // Se for recorrente, precisaria da lógica RPC. Por enquanto, inserimos uma
-        // O ideal é a lógica RPC handle_recurring, mas para simplificar:
-        const { error } = await supabase.from('transactions').insert([finalPayload]);
-        if (error) throw error;
-        toast.success('Transação salva!');
+        if (data.is_recurrent && Number(data.installments) > 1) {
+          const { error } = await supabase.rpc('handle_recurring_transactions', {
+            p_description: data.description,
+            p_amount: Number(data.amount),
+            p_date: data.date,
+            p_type: data.type,
+            p_category_id: data.category_id || null,
+            p_frequency: data.frequency,
+            p_installments: Number(data.installments),
+          });
+          if (error) throw error;
+          toast.success(`${data.installments} transações geradas com sucesso!`);
+        } else {
+          const { error } = await supabase.from('transactions').insert([finalPayload]);
+          if (error) throw error;
+          toast.success('Transação salva!');
+        }
       }
 
       onSuccess();

--- a/src/components/TransactionList.test.tsx
+++ b/src/components/TransactionList.test.tsx
@@ -11,7 +11,9 @@ vi.mock('./TransactionItem', () => ({
 
 vi.mock('framer-motion', () => ({
   motion: {
-    div: ({ children, ...props }: any) => <div {...props}>{children}</div>,
+    div: ({ children, layout, initial, animate, exit, transition, ...props }: any) => (
+      <div {...props}>{children}</div>
+    ),
   },
   AnimatePresence: ({ children }: any) => <>{children}</>,
 }));

--- a/src/pages/Categories.test.tsx
+++ b/src/pages/Categories.test.tsx
@@ -68,7 +68,9 @@ vi.mock('@/components/CategoryForm', () => ({
 
 vi.mock('framer-motion', () => ({
   motion: {
-    div: ({ children, ...props }: any) => <div {...props}>{children}</div>,
+    div: ({ children, layout, initial, animate, exit, transition, ...props }: any) => (
+      <div {...props}>{children}</div>
+    ),
   },
   AnimatePresence: ({ children }: any) => <>{children}</>,
 }));

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -10,6 +10,7 @@ export default mergeConfig(
       include: ['src/**/*.test.{ts,tsx}'],
       setupFiles: ['./src/test/setup.ts'],
       css: true,
+      testTimeout: 15000,
       coverage: {
         provider: 'v8',
         reporter: ['lcov', 'text'],


### PR DESCRIPTION
This pull request updates the transaction creation logic in the `TransactionForm` component to properly handle recurring transactions. Now, when a user creates a recurring transaction with more than one installment, the process uses a Supabase RPC call to generate multiple transactions at once, rather than inserting a single transaction.

**Recurring transactions handling:**

* Updated `TransactionForm` to call the `handle_recurring_transactions` Supabase RPC when creating a recurring transaction with more than one installment, passing all necessary parameters and displaying a success message with the number of generated transactions.

* For non-recurring or single-installment transactions, the existing logic of inserting a single record into the `transactions` table is retained.