### PR TITLE
chore: add google search console verification file

### DIFF
--- a/public/googleec4c89f62270a816.html
+++ b/public/googleec4c89f62270a816.html
@@ -1,0 +1,1 @@
+google-site-verification: googleec4c89f62270a816.html


### PR DESCRIPTION
This pull request adds a Google site verification file to the public directory. This is a standard step to verify site ownership with Google Search Console.

* Added `google-site-verification: googleec4c89f62270a816.html` to the `public` directory to enable Google Search Console verification.